### PR TITLE
Expand Snowflake/Databricks extraction and fix Databricks query-log path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,8 @@ Pre Assessment Requirements:
 
 > pip install pandas \
 > pip install pyarrow \
-> pip install databricks-sql-connector 
+> pip install databricks-sql-connector \
+> pip install requests
 
 Set environment variables pertaining to your databricks configurations (host, access_token, warehouse_id, etc.)
 
@@ -199,5 +200,5 @@ To run the assessment script :
 
 > python3 clients/main.py athena
 ```
-Two directories named <client>-metadata for Metadata and <client>-query-logs for Query Logs will be generated with the help of above script.
+A directory named <client>-logs containing both metadata and query log parquet files will be generated and then compressed into <client>-logs.zip.
 ```

--- a/clients/databricks/databricks_metadata.py
+++ b/clients/databricks/databricks_metadata.py
@@ -1,6 +1,5 @@
 from databricks import sql
 import pandas as pd
-from datetime import datetime, timedelta
 import os
 import time
 import logging
@@ -11,7 +10,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def extract_metadata(directory):
-    export_metadata = os.environ.get('EXPORT_METADATA', False)
+    export_metadata = str(os.environ.get('EXPORT_METADATA', '')).strip().lower() == 'true'
     catalog = 'system'
     database = 'information_schema'
     access_token = os.environ.get('DBR_ACCESS_TOKEN')
@@ -19,14 +18,6 @@ def extract_metadata(directory):
     dbr_server_hostname = os.environ.get('DBR_HOST')
     start_date_str = os.environ.get('QUERY_LOG_START')
     end_date_str = os.environ.get('QUERY_LOG_END')
-
-    # parse date bounds
-    try:
-        start_date = datetime.strptime(start_date_str, '%Y-%m-%d')
-        end_date   = datetime.strptime(end_date_str,   '%Y-%m-%d') + timedelta(days=1)
-    except Exception as e:
-        logger.error(f"Invalid date format: {e}")
-        raise
 
     output_dir = directory
     os.makedirs(output_dir, exist_ok=True)
@@ -53,8 +44,6 @@ def extract_metadata(directory):
                 raise
             time.sleep(10)
             return create_DBR_con(retry_count + 1)
-
-    conn = create_DBR_con()
 
     queries_metadata = {
         'tables': "SELECT * FROM system.information_schema.tables;",
@@ -155,51 +144,23 @@ def extract_metadata(directory):
         except Exception as e:
             logger.error(f"Error in {name}: {e}")
 
-    if export_metadata:
-        for name, q in queries_metadata.items():
+    conn = None
+    try:
+        conn = create_DBR_con()
+
+        if export_metadata:
+            for name, q in queries_metadata.items():
+                run_query_and_save(q, name)
+
+        for name, q in queries.items():
             run_query_and_save(q, name)
 
-    for name, q in queries.items():
-        run_query_and_save(q, name)
-
-    # hourly query history
-    def run_hourly_query_history(outdir):
-        current = start_date
-        while current < end_date:
-            next_hour = current + timedelta(hours=1)
-            st = current.strftime('%Y-%m-%d %H:%M:%S')
-            et = next_hour.strftime('%Y-%m-%d %H:%M:%S')
-            query = (
-                f"SELECT * FROM system.query.history"
-                f" WHERE start_time >= TIMESTAMP '{st}'"
-                f"   AND start_time <  TIMESTAMP '{et}'"
-            )
-            logger.info(f"Querying history from {st} to {et}")
-            with conn.cursor() as cur:
-                cur.execute(query)
-                data = cur.fetchall()
-                cols = [d[0] for d in cur.description]
-
-            if data:
-                df = pd.DataFrame(data, columns=cols)
-
-                for col in df.select_dtypes(include=["datetimetz"]).columns:
-                    df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
-
-                for col in df.select_dtypes(include=["datetime64[ns]"]).columns:
-                    df[col] = df[col].dt.round("ms")
-
-                table = pa.Table.from_pandas(df, preserve_index=False)
-                filename = f"query_history_{current.strftime('%Y%m%d_%H')}.parquet"
-
-                pq.write_table(
-                    table,
-                    os.path.join(outdir, filename),
-                    coerce_timestamps='ms'
-                )
-
-            current = next_hour
-
-    run_hourly_query_history(output_dir)
-    conn.close()
-    logger.info("Databricks metadata extraction completed.")
+        logger.info("Databricks metadata extraction completed.")
+    except Exception as e:
+        logger.error(f"Databricks metadata extraction failed: {e}")
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception as e:
+                logger.warning(f"Error closing connection: {e}")

--- a/clients/databricks/databricks_querylogs.py
+++ b/clients/databricks/databricks_querylogs.py
@@ -1,119 +1,150 @@
-from databricks import sql
-from datetime import datetime, timedelta
 import os
-import requests
 import time
 import logging
+from datetime import datetime, timedelta
+
+import requests
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+from databricks import sql
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
+
+def _write_parquet(df, path):
+    for col in df.select_dtypes(include=["datetimetz"]).columns:
+        df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    for col in df.select_dtypes(include=["datetime64[ns]"]).columns:
+        df[col] = df[col].dt.round("ms")
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    pq.write_table(table, path, coerce_timestamps='ms')
 
 
 def extract_query_logs(directory):
     catalog = 'system'
     database = 'information_schema'
     access_token = os.environ.get('DBR_ACCESS_TOKEN')
-    dbr_warehouse_id = os.environ.get('DBR_WAREHOUSE_ID')
+    http_path = os.environ.get('DBR_WAREHOUSE_HTTP')
     dbr_server_hostname = os.environ.get('DBR_HOST')
-    API_URL = f"https://{dbr_server_hostname}/api/2.0/sql/history/queries"
-    http_path=f'/sql/1.0/warehouses/{dbr_warehouse_id}'
-
-    logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger()
+    start_date_str = os.environ.get('QUERY_LOG_START')
+    end_date_str = os.environ.get('QUERY_LOG_END')
     parquet_output_dir = directory
     os.makedirs(parquet_output_dir, exist_ok=True)
-    def create_DBR_connection():
+
+    try:
+        start_date = datetime.strptime(start_date_str, '%Y-%m-%d')
+        end_date = datetime.strptime(end_date_str, '%Y-%m-%d') + timedelta(days=1)
+    except Exception as e:
+        logger.error(f"Invalid date format: {e}")
+        raise
+
+    def create_dbr_connection():
         return sql.connect(
             server_hostname=dbr_server_hostname,
             http_path=http_path,
             access_token=access_token,
             schema=database,
-            catalog=catalog
+            catalog=catalog,
         )
 
-    def create_DBR_con(retry_count=0):
-        max_retry_count = 3
-        logger.info(f'TIMESTAMP : {datetime.now()} Connecting to DBR database ...')
-        now = time.time()
+    def create_dbr_con_with_retry(retry_count=0):
+        max_retries = 3
         try:
-            dbr_connection = create_DBR_connection()
-            logger.info(
-                'TIMESTAMP : {} connected with database {} and catalog {} in {} seconds'.format(datetime.now(),
-                                                                                                database, catalog,
-                                                                                                time.time() - now))
-            return dbr_connection
-        except Exception as e:
-            logger.error(e)
-            logger.error(
-                'TIMESTAMP : {} Failed to connect to the DBR database with {}'.format(datetime.now(),
-                                                                                      database))
-            if retry_count > max_retry_count:
-                raise e
-            logger.error('Retry to connect in {} seconds...'.format(10))
-            retry_count += 1
-            return create_DBR_con(retry_count=retry_count)
+            logger.info(f"[{retry_count + 1}/{max_retries}] Connecting to Databricks SQL warehouse...")
+            conn = create_dbr_connection()
+            logger.info("Connected to Databricks SQL endpoint.")
+            return conn
+        except Exception as err:
+            logger.error(f"Connection failed: {err}")
+            if retry_count >= max_retries - 1:
+                raise
+            time.sleep(10)
+            return create_dbr_con_with_retry(retry_count + 1)
 
-    def fetch_query_history(start_time, end_time):
-        headers = {
-            "Authorization": f"Bearer {access_token}"
-        }
+    def system_query_history_accessible(conn):
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1 FROM system.query.history LIMIT 1")
+                cur.fetchall()
+            return True
+        except Exception as e:
+            logger.warning(f"system.query.history is not accessible: {e}")
+            return False
+
+    def extract_via_sql_hourly(conn):
+        current = start_date
+        while current < end_date:
+            next_hour = current + timedelta(hours=1)
+            st = current.strftime('%Y-%m-%d %H:%M:%S')
+            et = next_hour.strftime('%Y-%m-%d %H:%M:%S')
+            query = (
+                f"SELECT * FROM system.query.history"
+                f" WHERE start_time >= TIMESTAMP '{st}'"
+                f"   AND start_time <  TIMESTAMP '{et}'"
+            )
+            logger.info(f"Querying history from {st} to {et}")
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(query)
+                    data = cur.fetchall()
+                    cols = [d[0] for d in cur.description]
+            except Exception as e:
+                logger.error(f"Hourly chunk {st} failed: {e}")
+                current = next_hour
+                continue
+
+            if data:
+                df = pd.DataFrame(data, columns=cols)
+                filename = f"query_history_{current.strftime('%Y%m%d_%H')}.parquet"
+                _write_parquet(df, os.path.join(parquet_output_dir, filename))
+            current = next_hour
+
+    def fetch_query_history_via_rest(start_time_ms, end_time_ms):
+        api_url = f"https://{dbr_server_hostname}/api/2.0/sql/history/queries"
+        headers = {"Authorization": f"Bearer {access_token}"}
         query_history = []
         next_page_token = None
         max_pages = 10000
 
-        logger.info("Starting to fetch query history...")
-
+        logger.info("Starting to fetch query history via REST API...")
         for page_number in range(max_pages):
             payload = {
                 "filter_by": {
                     "statuses": ["FINISHED"],
-                    "start_time_ms": start_time,
-                    "end_time_ms": end_time
+                    "start_time_ms": start_time_ms,
+                    "end_time_ms": end_time_ms,
                 },
                 "include_metrics": True,
-                "max_results": 100
+                "max_results": 100,
             }
-
             if next_page_token:
                 payload["page_token"] = next_page_token
 
             try:
-                response = requests.get(API_URL, json=payload, headers=headers)
+                response = requests.get(api_url, json=payload, headers=headers)
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
                 logger.error(f"Error during API call on page {page_number + 1}: {e}")
                 break
 
             response_data = response.json()
-
-
             queries = response_data.get('res', [])
             query_history.extend(queries)
-            logger.info(f"Page {page_number + 1}: Fetched {len(queries)} queries. Total so far: {len(query_history)}")
+            logger.info(f"Page {page_number + 1}: fetched {len(queries)}. Total: {len(query_history)}")
 
             next_page_token = response_data.get("next_page_token", None)
-
             if not response_data.get("has_more", True) or not next_page_token:
-                logger.info("No more pages to fetch.")
                 break
-
             time.sleep(0.5)
 
-        logger.info(f"Filtering out system-generated queries. Initial count: {len(query_history)}")
         query_history = [
-            query for query in query_history
-            if "This is a system generated query from sql editor" not in query.get("query_text", "")
+            q for q in query_history
+            if "This is a system generated query from sql editor" not in q.get("query_text", "")
         ]
-        logger.info(f"Filtered query count: {len(query_history)}")
+        return query_history
 
-        output_parquet = f"{parquet_output_dir}/query_history_output.parquet"
-        save_query_history_to_parquet(query_history, output_parquet)
-
-    def save_query_history_to_parquet(query_history, output_parquet):
+    def save_rest_history_to_parquet(query_history, output_parquet):
         if not query_history:
             logger.info(f"No data to write in {output_parquet}")
             return
@@ -155,77 +186,40 @@ def extract_query_logs(directory):
                 "pruned_files_count": metrics.get("pruned_files_count"),
                 "provisioning_queue_start_timestamp": metrics.get("provisioning_queue_start_timestamp"),
                 "overloading_queue_start_timestamp": metrics.get("overloading_queue_start_timestamp"),
-                "query_compilation_start_timestamp": metrics.get("query_compilation_start_timestamp")
+                "query_compilation_start_timestamp": metrics.get("query_compilation_start_timestamp"),
             })
 
         df = pd.DataFrame(data)
-        for col in df.select_dtypes(include=["datetimetz"]).columns:
-            df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
-
-        for col in df.select_dtypes(include=["datetime64[ns]"]).columns:
-            df[col] = df[col].dt.round("ms")
-
-        table = pa.Table.from_pandas(df, preserve_index=False)
-
-        pq.write_table(
-            table,
-            output_parquet,
-            coerce_timestamps='ms'
-        )
-
-        df.to_parquet(output_parquet, engine='fastparquet', index=False)
+        _write_parquet(df, output_parquet)
         logger.info(f"Query history exported to {output_parquet}")
 
-    def fetch_query_history_by_date(start_date_str, end_date_str):
-        start_time = datetime.strptime(start_date_str, "%Y-%m-%d")
-        end_time = datetime.strptime(end_date_str, "%Y-%m-%d") + timedelta(days=1) - timedelta(milliseconds=1)
-        start_time_ms = int(start_time.timestamp() * 1000)
-        end_time_ms = int(end_time.timestamp() * 1000)
+    def extract_via_rest():
+        start_ms = int(start_date.timestamp() * 1000)
+        end_ms = int((end_date - timedelta(milliseconds=1)).timestamp() * 1000)
+        history = fetch_query_history_via_rest(start_ms, end_ms)
+        output_parquet = os.path.join(parquet_output_dir, "query_history_output.parquet")
+        save_rest_history_to_parquet(history, output_parquet)
 
-        fetch_query_history(start_time_ms, end_time_ms)
-
-
-    def run_query_rest(query: str):
-        headers = {
-            'Authorization': f"Bearer {access_token}",
-            'Content-Type': 'application/json'
-        }
-        url = f"https://{dbr_server_hostname}/api/2.0/sql/statements"
-        payload = {'statement': query, 'warehouse_id': dbr_warehouse_id}
-        r = requests.post(url, headers=headers, json=payload)
-        r.raise_for_status()
-        sid = r.json()['statement_id']
-        logger.info(f"Submitted {sid}")
-
-        status_url = f"{url}/{sid}"
-        while True:
-            r = requests.get(status_url, headers=headers)
-            r.raise_for_status()
-            j = r.json()
-            state = j['status']['state']
-            if state in ('SUCCEEDED', 'FAILED', 'CANCELED'):
-                break
-            time.sleep(1)
-        if state != 'SUCCEEDED':
-            raise RuntimeError(f"Query {sid} failed: {state}")
-
-        cols = [c['name'] for c in j.get('manifest', {}).get('schema', {}).get('columns', [])]
-        data = j.get('result', {}).get('data_array', [])
-        return cols, data
-
-    start_date = os.environ.get('QUERY_LOG_START')
-    end_date = os.environ.get('QUERY_LOG_END')
-
-    def history_exists_via_rest():
+    conn = None
+    try:
         try:
-            cols, rows = run_query_rest("SELECT 1 FROM system.query.history LIMIT 1")
-            return bool(rows)
+            conn = create_dbr_con_with_retry()
         except Exception as e:
-            logger.warning(f"History‐exists check failed: Fetching query for Query History API")
-            return False
+            logger.warning(f"Could not connect to SQL warehouse ({e})")
 
-    if not history_exists_via_rest():
-        fetch_query_history_by_date(start_date, end_date)
-    else:
-        logger.info("SYSTEM QUERY HISTORY ALREADY POPULATED – skipping fetch_query_history_by_date")
+        use_sql_path = conn is not None and system_query_history_accessible(conn)
 
+        if use_sql_path:
+            logger.info("Extracting query history via system.query.history (hourly chunks)...")
+            extract_via_sql_hourly(conn)
+        else:
+            logger.info("Falling back to Query History REST API...")
+            extract_via_rest()
+    except Exception as e:
+        logger.error(f"Query log extraction failed: {e}")
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception as e:
+                logger.warning(f"Error closing connection: {e}")

--- a/clients/main.py
+++ b/clients/main.py
@@ -44,7 +44,7 @@ def extractor(engine_type):
         except Exception as e:
             logger.error(f"Error during metadata extraction: {str(e)}")
     module = dynamic_import(engine_type, 'querylogs')
-    if module and engine_type != 'databricks':
+    if module:
         logger.info(f"Running {engine_type.capitalize()} Query Log extractor...")
         try:
             module.extract_query_logs(output_dir)

--- a/clients/snowflake/snowflake_common.py
+++ b/clients/snowflake/snowflake_common.py
@@ -1,0 +1,97 @@
+import os
+import time
+import logging
+import snowflake.connector
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATABASE = 'SNOWFLAKE'
+DEFAULT_SCHEMA = 'ACCOUNT_USAGE'
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RETRY_DELAY_SECONDS = 10
+
+
+def _resolve_passphrase():
+    passphrase = os.environ.get('SNOWFLAKE_PRIVATE_KEY_PASSPHRASE') or None
+    fmt = os.environ.get('SNOWFLAKE_PASSPHRASE_INPUT_FORMAT') or 'STRING'
+    if passphrase and fmt == 'TEXT_FILE':
+        with open(passphrase) as f:
+            passphrase = f.read().strip()
+    return passphrase
+
+
+def _connect_once():
+    host = os.environ.get('SNOWFLAKE_ACCOUNT_IDENTIFIER')
+    user = os.environ.get('SNOWFLAKE_USER')
+    warehouse = os.environ.get('SNOWFLAKE_WAREHOUSE')
+    auth_type = os.environ.get('SNOWFLAKE_AUTH_TYPE')
+
+    common_kwargs = dict(
+        user=user,
+        account=host,
+        warehouse=warehouse,
+        database=DEFAULT_DATABASE,
+        schema=DEFAULT_SCHEMA,
+    )
+
+    if auth_type == 'USERNAME_PASSWORD':
+        password = os.environ.get('SNOWFLAKE_PASSWORD')
+        return snowflake.connector.connect(password=password, **common_kwargs)
+    if auth_type == 'KEY_PAIR':
+        private_key = os.environ.get('SNOWFLAKE_PRIVATE_KEY_PATH')
+        passphrase = _resolve_passphrase()
+        return snowflake.connector.connect(
+            private_key_file=private_key,
+            private_key_file_pwd=passphrase,
+            **common_kwargs,
+        )
+    raise ValueError(
+        f"Invalid SNOWFLAKE_AUTH_TYPE: {auth_type!r}. "
+        "Must be 'USERNAME_PASSWORD' or 'KEY_PAIR'."
+    )
+
+
+def connect_with_retry(max_retries=DEFAULT_MAX_RETRIES,
+                       retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS):
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            logger.info(f"[{attempt}/{max_retries}] Creating connection with Snowflake")
+            conn = _connect_once()
+            logger.info("Connected to Snowflake")
+            return conn
+        except Exception as e:
+            logger.error(f"Connection attempt {attempt} failed: {e}")
+            if attempt >= max_retries:
+                raise
+            time.sleep(retry_delay_seconds)
+
+
+def use_role(cursor, role):
+    cursor.execute(f"USE ROLE {role};")
+    logger.info(f"Using {role}")
+
+
+def close_quietly(cursor, conn):
+    if cursor is not None:
+        try:
+            cursor.close()
+        except Exception as e:
+            logger.warning(f"Error closing cursor: {e}")
+    if conn is not None:
+        try:
+            conn.close()
+        except Exception as e:
+            logger.warning(f"Error closing connection: {e}")
+
+
+def write_parquet(df, path):
+    for col in df.select_dtypes(include=["datetimetz"]).columns:
+        df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)
+    for col in df.select_dtypes(include=["datetime64[ns]"]).columns:
+        df[col] = df[col].dt.round("ms")
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    pq.write_table(table, path, coerce_timestamps='ms')

--- a/clients/snowflake/snowflake_metadata.py
+++ b/clients/snowflake/snowflake_metadata.py
@@ -1,7 +1,14 @@
-import snowflake.connector
-import pandas as pd
 import os
 import logging
+
+import pandas as pd
+
+from snowflake.snowflake_common import (
+    connect_with_retry,
+    use_role,
+    close_quietly,
+    write_parquet,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -11,90 +18,54 @@ def run_query_and_save_to_csv(cursor, query, csv_filename, csv_output_dir):
         logger.info(f"Executing query for {csv_filename} metadata")
         cursor.execute(query)
         result = cursor.fetchall()
-
         columns = [desc[0] for desc in cursor.description]
-
         df = pd.DataFrame(result, columns=columns)
-
         output_path = os.path.join(csv_output_dir, f'{csv_filename}.parquet')
-        df.to_parquet(output_path, index=False)
+        write_parquet(df, output_path)
         logger.info(f"Data written to {csv_filename}")
     except Exception as e:
         logger.error(f"Failed to execute query for {csv_filename}: {e}")
 
 
 def extract_metadata(directory):
-    host = os.environ.get('SNOWFLAKE_ACCOUNT_IDENTIFIER')
-    warehouse = os.environ.get('SNOWFLAKE_WAREHOUSE')
-    user = os.environ.get('SNOWFLAKE_USER')
-    auth_type = os.environ.get('SNOWFLAKE_AUTH_TYPE')
-    password = os.environ.get('SNOWFLAKE_PASSWORD')
-    private_key = os.environ.get('SNOWFLAKE_PRIVATE_KEY_PATH')
-    private_key_passphrase = os.environ.get('SNOWFLAKE_PRIVATE_KEY_PASSPHRASE') or None
-    passphrase_input_format = os.environ.get('SNOWFLAKE_PASSPHRASE_INPUT_FORMAT') or 'STRING'
-    if private_key_passphrase and passphrase_input_format == 'TEXT_FILE':
-        with open(private_key_passphrase) as f:
-            private_key_passphrase = f.read().strip()
     role = os.environ.get('SNOWFLAKE_ROLE')
     query_log_start = os.environ.get('QUERY_LOG_START')
     query_log_end = os.environ.get('QUERY_LOG_END')
-    database = 'SNOWFLAKE'
-    schema = 'ACCOUNT_USAGE'
-    csv_output_dir = directory
-    os.makedirs(csv_output_dir, exist_ok=True)
+    os.makedirs(directory, exist_ok=True)
+
+    queries = {
+        'tables': """SELECT a.*, b.view_definition
+                FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES a
+                LEFT JOIN SNOWFLAKE.ACCOUNT_USAGE.VIEWS b
+                    ON a.table_catalog = b.table_catalog
+                    AND a.table_schema = b.table_schema
+                    AND a.table_name = b.table_name
+                WHERE a.DELETED IS NULL AND a.table_catalog NOT IN ('SNOWFLAKE')""",
+        'views': """SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.VIEWS
+                    WHERE DELETED IS NULL AND table_catalog NOT IN ('SNOWFLAKE')""",
+        'columns': """SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.COLUMNS
+                    WHERE DELETED IS NULL AND table_catalog NOT IN ('SNOWFLAKE')""",
+        'functions': """SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS
+                    WHERE DELETED IS NULL AND function_catalog NOT IN ('SNOWFLAKE')""",
+        'warehouse': """SHOW WAREHOUSES""",
+        'warehouse_usage': f"""SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY
+                                WHERE DATE(start_time) between date('{query_log_start}')
+                                AND date('{query_log_end}') """
+    }
+
+    conn = None
+    cursor = None
     try:
-        logger.info("Creating connection with Snowflake")
-        if auth_type == 'USERNAME_PASSWORD':
-            conn = snowflake.connector.connect(
-                user=user,
-                password=password,
-                account=host,
-                warehouse=warehouse,
-                database=database,
-                schema=schema
-            )
-        elif auth_type == 'KEY_PAIR':
-            conn = snowflake.connector.connect(
-                user=user,
-                private_key_file=private_key,
-                private_key_file_pwd=private_key_passphrase,
-                account=host,
-                warehouse=warehouse,
-                database=database,
-                schema=schema
-            )
-        else:
-            raise ValueError(
-                f"Invalid SNOWFLAKE_AUTH_TYPE: {auth_type!r}. "
-                "Must be 'USERNAME_PASSWORD' or 'KEY_PAIR'."
-            )
-
-        queries = {
-            'tables': """SELECT a.table_catalog, a.table_schema, a.table_name, a.table_type, a.row_count, a.bytes, 
-                    a.clustering_key,b.view_definition FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES a left join 
-                    SNOWFLAKE.ACCOUNT_USAGE.VIEWS b on a.table_catalog=b.table_catalog and a.table_schema=b.table_schema
-                     and a.table_name=b.table_name WHERE a.DELETED IS NULL and a.table_catalog not in ('SNOWFLAKE')""",
-            'columns': """SELECT table_catalog, table_schema, table_name, ordinal_position, column_name, data_type 
-                        FROM SNOWFLAKE.ACCOUNT_USAGE.COLUMNS WHERE DELETED IS NULL""",
-            'functions': """SELECT function_schema, function_name, data_type, FUNCTION_LANGUAGE, FUNCTION_DEFINITION, 
-                        argument_signature FROM SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS WHERE DELETED IS NULL""",
-            'warehouse': """SHOW WAREHOUSES""",
-            'warehouse_usage': f"""SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY
-                                    WHERE DATE(start_time) between date('{query_log_start}')
-                                    AND date('{query_log_end}') """
-        }
-
+        conn = connect_with_retry()
         cursor = conn.cursor()
-        logger.info("Connected to Snowflake.")
-
-        use_admin_role = f"USE ROLE {role};"
-        cursor.execute(use_admin_role)
-        logger.info(f"Using {role} for extracting metadata")
+        use_role(cursor, role)
+        logger.info("Using role for extracting metadata")
 
         for csv_filename, query in queries.items():
-            run_query_and_save_to_csv(cursor, query, csv_filename, csv_output_dir)
-        cursor.close()
-        conn.close()
-        logger.info("Connection Closed.")
+            run_query_and_save_to_csv(cursor, query, csv_filename, directory)
+        logger.info("Metadata extraction completed.")
     except Exception as e:
-        logger.error(f"Error extracting Snowflake metadata: {str(e)}")
+        logger.error(f"Error extracting Snowflake metadata: {e}")
+    finally:
+        close_quietly(cursor, conn)
+        logger.info("Connection Closed.")

--- a/clients/snowflake/snowflake_querylogs.py
+++ b/clients/snowflake/snowflake_querylogs.py
@@ -1,100 +1,103 @@
-import snowflake.connector
-from datetime import datetime
-import pandas as pd
 import os
 import logging
+from datetime import datetime
+
+import pandas as pd
+
+from snowflake.snowflake_common import (
+    connect_with_retry,
+    use_role,
+    close_quietly,
+    write_parquet,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def extract_query_logs(directory):
-    host = os.environ.get('SNOWFLAKE_ACCOUNT_IDENTIFIER')
-    user = os.environ.get('SNOWFLAKE_USER')
     role = os.environ.get('SNOWFLAKE_ROLE')
-    warehouse = os.environ.get('SNOWFLAKE_WAREHOUSE')
-    auth_type = os.environ.get('SNOWFLAKE_AUTH_TYPE')
-    password = os.environ.get('SNOWFLAKE_PASSWORD')
-    private_key = os.environ.get('SNOWFLAKE_PRIVATE_KEY_PATH')
-    private_key_passphrase = os.environ.get('SNOWFLAKE_PRIVATE_KEY_PASSPHRASE') or None
-    passphrase_input_format = os.environ.get('SNOWFLAKE_PASSPHRASE_INPUT_FORMAT') or 'STRING'
-    if private_key_passphrase and passphrase_input_format == 'TEXT_FILE':
-        with open(private_key_passphrase) as f:
-            private_key_passphrase = f.read().strip()
-    database = 'SNOWFLAKE'
-    schema = 'ACCOUNT_USAGE'
     query_log_start = os.environ.get('QUERY_LOG_START')
     query_log_end = os.environ.get('QUERY_LOG_END')
-    csv_output_dir = directory
-    os.makedirs(csv_output_dir, exist_ok=True)
+    os.makedirs(directory, exist_ok=True)
 
+    start_date = datetime.strptime(query_log_start, '%Y-%m-%d')
+    end_date = datetime.strptime(query_log_end, '%Y-%m-%d')
+    start_timestamp = start_date.strftime('%Y-%m-%dT00:00:00Z')
+    end_timestamp = end_date.strftime('%Y-%m-%dT23:59:59Z')
+
+    conn = None
+    cursor = None
     try:
-        logger.info("Creating connection with Snowflake")
-        if auth_type == 'USERNAME_PASSWORD':
-            conn = snowflake.connector.connect(
-                user=user,
-                password=password,
-                account=host,
-                warehouse=warehouse,
-                database=database,
-                schema=schema
-            )
-        elif auth_type == 'KEY_PAIR':
-            conn = snowflake.connector.connect(
-                user=user,
-                private_key_file=private_key,
-                private_key_file_pwd=private_key_passphrase,
-                account=host,
-                warehouse=warehouse,
-                database=database,
-                schema=schema
-            )
-        else:
-            raise ValueError(
-                f"Invalid SNOWFLAKE_AUTH_TYPE: {auth_type!r}. "
-                "Must be 'USERNAME_PASSWORD' or 'KEY_PAIR'."
-            )
+        conn = connect_with_retry()
         cursor = conn.cursor()
-        logger.info("Connected to snowflake")
-        cursor.execute(f"USE ROLE {role};")
-        logger.info(f"Using {role} for extracting query logs")
-
-        start_date = datetime.strptime(query_log_start, '%Y-%m-%d')
-        end_date = datetime.strptime(query_log_end, '%Y-%m-%d')
-
-        start_timestamp = start_date.strftime('%Y-%m-%dT00:00:00Z')
-        end_timestamp = end_date.strftime('%Y-%m-%dT23:59:59Z')
+        use_role(cursor, role)
+        logger.info("Using role for extracting query logs")
 
         history_query = f"""
-            SELECT query_id, query_text, database_name, schema_name, query_type, 
-                       user_name, warehouse_size, execution_status, 
-                       error_message, start_time, end_time, bytes_scanned, 
-                       percentage_scanned_from_cache, bytes_written, rows_produced,
-                       partitions_scanned, partitions_total, bytes_spilled_to_local_storage, 
-                       bytes_spilled_to_remote_storage, bytes_sent_over_the_network, 
-                       total_elapsed_time, compilation_time, execution_time, queued_overload_time,
-                       credits_used_cloud_services 
-            FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY 
-            WHERE end_time >= to_timestamp_ltz('{start_timestamp}') 
-            AND end_time <= to_timestamp_ltz('{end_timestamp}') 
+            SELECT reader_account_name, query_id, query_text,
+                       database_id, database_name, schema_id, schema_name, query_type,
+                       session_id, authn_event_id,
+                       user_name, role_name,
+                       warehouse_id, warehouse_name, warehouse_size, warehouse_type,
+                       cluster_number, query_tag, execution_status,
+                       error_code, error_message, start_time, end_time,
+                       total_elapsed_time,
+                       bytes_scanned, percentage_scanned_from_cache,
+                       bytes_written, bytes_written_to_result, bytes_read_from_result,
+                       rows_produced, rows_inserted, rows_updated, rows_deleted,
+                       rows_unloaded, bytes_deleted,
+                       partitions_scanned, partitions_total,
+                       bytes_spilled_to_local_storage, bytes_spilled_to_remote_storage,
+                       bytes_sent_over_the_network,
+                       compilation_time, execution_time,
+                       queued_provisioning_time, queued_repair_time, queued_overload_time,
+                       transaction_blocked_time,
+                       outbound_data_transfer_cloud, outbound_data_transfer_region,
+                       outbound_data_transfer_bytes,
+                       inbound_data_transfer_cloud, inbound_data_transfer_region,
+                       inbound_data_transfer_bytes,
+                       list_external_files_time,
+                       credits_used_cloud_services,
+                       reader_account_deleted_on,
+                       release_version,
+                       external_function_total_invocations,
+                       external_function_total_sent_rows, external_function_total_received_rows,
+                       external_function_total_sent_bytes, external_function_total_received_bytes,
+                       query_load_percent, is_client_generated_statement,
+                       query_acceleration_bytes_scanned, query_acceleration_partitions_scanned,
+                       query_acceleration_upper_limit_scale_factor,
+                       transaction_id, child_queries_wait_time, role_type,
+                       query_hash, query_hash_version,
+                       query_parameterized_hash, query_parameterized_hash_version,
+                       secondary_role_stats,
+                       rows_written_to_result,
+                       query_retry_time, query_retry_cause, fault_handling_time,
+                       user_type,
+                       user_database_name, user_database_id,
+                       user_schema_name, user_schema_id,
+                       bind_values
+            FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
+            WHERE end_time >= to_timestamp_ltz('{start_timestamp}')
+            AND end_time <= to_timestamp_ltz('{end_timestamp}')
             AND is_client_generated_statement = FALSE;
         """
-        logger.info(f"Fetching query history it may take few minutes...")
+        logger.info("Fetching query history; this may take a few minutes...")
         cursor.execute(history_query)
         result = cursor.fetchall()
-        if result:
-            columns = [col[0] for col in cursor.description]
-            df = pd.DataFrame(result, columns=columns)
-            df["START_TIME"] = df["START_TIME"].astype(str)
-            df["END_TIME"] = df["END_TIME"].astype(str)
-            logger.info(f"Writing query history into parquet...")
-            parquet_filename = f"{csv_output_dir}/query_history_snowflake_1.parquet"
-            df.to_parquet(parquet_filename, index=False)
-            logger.info(f"Data has been exported to {os.path.basename(parquet_filename)}")
-            logger.info(f"Query Log Successfully Exported to {csv_output_dir}")
-        else:
+
+        if not result:
             logger.info("No queries found for the specified date range.")
-            cursor.close()
-            conn.close()
+            return
+
+        columns = [col[0] for col in cursor.description]
+        df = pd.DataFrame(result, columns=columns)
+        parquet_path = os.path.join(directory, "query_history_snowflake.parquet")
+        logger.info("Writing query history into parquet...")
+        write_parquet(df, parquet_path)
+        logger.info(f"Data has been exported to {os.path.basename(parquet_path)}")
+        logger.info(f"Query Log Successfully Exported to {directory}")
 
     except Exception as e:
-        logger.error(f"Failed to connect with Snowflake: {str(e)}")
+        logger.error(f"Failed during Snowflake query log extraction: {e}")
+    finally:
+        close_quietly(cursor, conn)


### PR DESCRIPTION
Snowflake:
- Add snowflake_common.py with shared connect-with-retry, role, parquet-write, and cleanup helpers
- Fetch full column sets from QUERY_HISTORY, TABLES, VIEWS, COLUMNS, FUNCTIONS; filter SNOWFLAKE system DB consistently
- Fix connection leaks via try/finally; robust timestamp handling (UTC-naive, ms-rounded) replaces brittle astype(str)
- Drop misleading _1 suffix from query_history parquet filename

Databricks:
- Unblock databricks_querylogs.py: main.py no longer skips it
- Move hourly query-history extraction out of databricks_metadata.py into databricks_querylogs.py; gate it on a system.query.history accessibility probe with REST API fallback
- Add try/finally connection cleanup in databricks_metadata.py

Readme: add requests to Databricks pip list; update output-dir description.