### PR TITLE
Fix: Handle numpy ndarray serialization in query log extraction

### DIFF
--- a/clients/databricks/databricks_querylogs.py
+++ b/clients/databricks/databricks_querylogs.py
@@ -4,6 +4,7 @@ import json
 import logging
 from datetime import datetime, timedelta
 
+import numpy as np
 import requests
 import pandas as pd
 import pyarrow as pa
@@ -14,13 +15,20 @@ logger = logging.getLogger(__name__)
 
 
 def _write_parquet(df, path):
-    # Convert dict/list columns to JSON strings (e.g., query_parameters)
+    # Convert dict/list/ndarray columns to JSON strings (e.g., query_parameters)
+    def serialize_value(x):
+        if isinstance(x, np.ndarray):
+            return json.dumps(x.tolist())
+        elif isinstance(x, (dict, list)):
+            return json.dumps(x)
+        return x
+
     for col in df.columns:
         if df[col].dtype == 'object':
-            # Check if any value in the column is a dict or list
+            # Check if any value in the column is a dict, list, or ndarray
             sample = df[col].dropna().head(1)
-            if len(sample) > 0 and isinstance(sample.iloc[0], (dict, list)):
-                df[col] = df[col].apply(lambda x: json.dumps(x) if isinstance(x, (dict, list)) else x)
+            if len(sample) > 0 and isinstance(sample.iloc[0], (dict, list, np.ndarray)):
+                df[col] = df[col].apply(serialize_value)
 
     for col in df.select_dtypes(include=["datetimetz"]).columns:
         df[col] = df[col].dt.tz_convert("UTC").dt.tz_localize(None)


### PR DESCRIPTION
ndarray objects from Databricks query results cannot be JSON serialized directly. Convert them to Python lists before serialization.